### PR TITLE
get rid of clear_X() method

### DIFF
--- a/rankeval/dataset/dataset.py
+++ b/rankeval/dataset/dataset.py
@@ -244,16 +244,6 @@ class Dataset(object):
         return Dataset(self.X[mask], self.y[mask],
                        qid_map[mask], name=name)
 
-    def clear_X(self):
-        """
-        This method clears the space used by the dataset instance for storing X
-        (the dataset features). This space is used only for scoring, thus it
-        can be freed after.
-
-        """
-        del self.X
-        self.X = None
-
     def query_iterator(self):
         """
         This method implements and iterator over the offsets of the query_ids


### PR DESCRIPTION
This method is not used.

Moreover, the effect of "del self.x" is reset immediately by assigning None to it.
If someone wanted to get the effect of dataset.clear_X(), they could also just do dataset.X = None instead.