### PR TITLE
use .sum() method to also support sparse matrices

### DIFF
--- a/rankeval/dataset/dataset.py
+++ b/rankeval/dataset/dataset.py
@@ -323,7 +323,7 @@ class Dataset(object):
         return self.name
 
     def __hash__(self):
-        return int( sum(self.y[:100]) + sum(self.X[:100,0]) )
+        return int( self.y[:100].sum() + self.X[:100,0].sum() )
 
     def __eq__(self, other):
         return (self.X == other.X).all() and \


### PR DESCRIPTION
When using a sparse matrix, e.g. scipy.sparse.csr_matrix, we otherwise get the error message: "NotImplementedError: adding a nonzero scalar to a sparse matrix is not supported".
With the .sum(), method, it works for both sparse and dense (numpy array) matrices.

This little change allows us to handle much bigger sparse datasets.
Memory saving depends on the dataset, I observed a factor of 7 for a dataset with about 5% density.